### PR TITLE
Uzantısı Değişen Resimlerde resim thumb edilemiyordu. Bu özelliği hat…

### DIFF
--- a/Internal/ImageProcessing/Image/RenderImage.php
+++ b/Internal/ImageProcessing/Image/RenderImage.php
@@ -182,22 +182,22 @@ class RenderImage
     protected function fromFileType($paths)
     {
         // UZANTI JPG
-        if( File::extension($this->file) === 'jpg' )
+        if(mime_content_type($this->file) == "image/jpeg" )
         {
             return imagecreatefromjpeg($paths);
         }
         // UZANTI JPEG
-        elseif( File::extension($this->file) === 'jpeg' )
+        elseif(mime_content_type($this->file) == "image/jpeg" )
         {
             return imagecreatefromjpeg($paths);
         }
         // UZANTI PNG
-        elseif( File::extension($this->file) === 'png' )
+        elseif(mime_content_type($this->file) == "image/png" )
         {
             return imagecreatefrompng($paths);
         }
         // UZANTI GIF
-        elseif( File::extension($this->file) === 'gif' )
+        elseif(mime_content_type($this->file) == "image/gif" )
         {
             return imagecreatefromgif($paths);
         }


### PR DESCRIPTION
…a fırlatıyordu. Resim oluşturulurken uzantıdan bahımsız şekilde hash tablosuna bakarak oluşturması gereken thumb u oluşturması için güncelleme yapılmıştır.